### PR TITLE
1.1.0 features

### DIFF
--- a/src/main/java/com/gruchalski/kafka/java8/KafkaCluster.java
+++ b/src/main/java/com/gruchalski/kafka/java8/KafkaCluster.java
@@ -98,8 +98,16 @@ public class KafkaCluster {
      * @tparam <T> type of the value to send
      * @return the metadata / error future
      */
-    public <T> Optional<CompletableFuture<RecordMetadata>> produce(String topic, SerializerProvider<T> value, ProducerCallback callback) {
-        Optional<scala.concurrent.Future<RecordMetadata>> optional = ScalaCompat.fromScala(cluster.produce(topic, value, callback.callback));
+    public <T> Optional<CompletableFuture<RecordMetadata>> produce(String topic, SerializerProvider<T> value, com.gruchalski.kafka.java8.ProducerCallback callback)
+    throws Throwable {
+        // left is an error:
+        scala.util.Try<scala.Option<scala.concurrent.Future<RecordMetadata>>> _try = cluster.produce(topic, value, callback.callback);
+        scala.util.Either<Throwable, scala.Option<scala.concurrent.Future<RecordMetadata>>> _either = _try.toEither();
+        if (_either.isLeft()) {
+            throw _either.left().get();
+        }
+        // well, else if right...
+        Optional<scala.concurrent.Future<RecordMetadata>> optional = ScalaCompat.fromScala(_either.right().get());
         if (optional.isPresent()) {
             return Optional.ofNullable(ScalaCompat.fromScala(optional.get()));
         } else {
@@ -114,7 +122,13 @@ public class KafkaCluster {
      * @tparam <T> type of the message to consume
      * @return a consumed object, if available at the time of the call
      */
-    public <T extends DeserializerProvider<?>> Optional<ConsumedItem<T>> consume(String topic, Deserializer<T> deserializer) {
-        return ScalaCompat.fromScala(cluster.consume(topic, deserializer));
+    public <T extends DeserializerProvider<?>> Optional<ConsumedItem<T>> consume(String topic, Deserializer<T> deserializer)
+    throws Throwable {
+        scala.util.Try<scala.Option<ConsumedItem<T>>> _try = cluster.consume(topic, deserializer);
+        scala.util.Either<Throwable, scala.Option<ConsumedItem<T>>> _either = _try.toEither();
+        if (_either.isLeft()) {
+            throw _either.left().get();
+        }
+        return ScalaCompat.fromScala(_either.right().get());
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,7 +1,16 @@
+# Kafka cluster tools configuration
 com.gruchalski {
+
+  # Number of ZooKeeper servers for the underlying ZooKeeper ensemble.
+  # Use 1, 3 or 5.
   zookeeper.server.ensemble-size = 1
   kafka {
+
+    # Number of Kafka machines in the test cluster.
     cluster.size = 1
+
+    # Broker configuration.
+    # These settings are the defaults for Kafka and you most likely do not want to change them for unit tests.
     broker {
       enable-controlled-shutdown = true
       enable-delete-topic = false
@@ -11,6 +20,9 @@ com.gruchalski {
       enable-sasl-ssl = false
       rack-info = null
     }
+
+    # Kafka cluster tools producer settings.
+    # These settings are the defaults for Kafka and you most likely do not want to change them for unit tests.
     producer {
       acks = -1
       max-block-ms = 60000
@@ -20,14 +32,47 @@ com.gruchalski {
       request-timeout-ms = 10240
       security-protocol = "plaintext"
     }
+
+    # Kafka cluster tools consumer settings.
+    # These settings are the defaults for Kafka and you most likely do not want to change them for unit tests.
+    # Except of the poll-timeout-ms!
     consumer {
       group-id = "group"
       auto-offset-reset = "earliest",
       partition-fetch-size = 4096,
       session-timeout = 30000
-      poll-timeout-ms = 200 # custom setting
+      security-protocol = "plaintext"
+      # How long for does the KafkaCluster.consume() underlying task awaits for the messages until rescheduling.
+      poll-timeout-ms = 200
     }
-    security-protocol = "plaintext"
+
+    # How long for to wait for the topic to appear in Kafka after requesting creating the topic
+    # until considering the request to be unsuccessful.
     topic-wait-for-create-success-timeout-ms = 1000
+
+    # It's possible to define topics here as well. Topic list can be defined like this:
+    #
+    # topic.0 {
+    #   name = "topic-name.1"
+    #   partitions = 2
+    #   rackAwareMode = "enforced"
+    # }
+    #
+    # topic.1 {
+    #   name = "topic-name.2"
+    # }
+    #
+    # Keep the sequence...
+    #
+    # topic.N {
+    #   name = "topic-name.N"
+    #   partitions = number, default is 1
+    #   replicationFactor = number, no more than number of brokers, default is 1
+    #   rackAwareMode = enforced, disabled or safe
+    # }
+    #
+    # Topics aren't created automatically but the topics defined here become available under the
+    # Configuration.`com.gruchalski.kafka.topics` configuration key. These can be passed directly to
+    # KafkaCluster.withTopics method.
   }
 }

--- a/src/main/scala/com/gruchalski/kafka/scala/Exceptions.scala
+++ b/src/main/scala/com/gruchalski/kafka/scala/Exceptions.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 Radek Gruchalski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gruchalski.kafka.scala
+
+class NoTopicException(val topic: String) extends Exception(topic)

--- a/src/test/java/com/gruchalski/kafka/test/serializer/java8/IdProvider.java
+++ b/src/test/java/com/gruchalski/kafka/test/serializer/java8/IdProvider.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.gruchalski.kafka.serializer.java8.concrete;
+package com.gruchalski.kafka.test.serializer.java8;
 
-import com.gruchalski.kafka.serializer.java8.IdProvider;
-
-public abstract class JavaConcreteMessageType implements IdProvider {
+public interface IdProvider {
+    int id();
 }

--- a/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/ConcreteJavaMessageImplementation.java
+++ b/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/ConcreteJavaMessageImplementation.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.gruchalski.kafka.serializer.java8.concrete;
+package com.gruchalski.kafka.test.serializer.java8.concrete;
 
 import com.gruchalski.kafka.scala.DeserializerProvider;
 import com.gruchalski.kafka.scala.SerializerProvider;

--- a/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/JavaConcreteDeserializer.java
+++ b/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/JavaConcreteDeserializer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.gruchalski.kafka.serializer.java8.concrete;
+package com.gruchalski.kafka.test.serializer.java8.concrete;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.msgpack.core.MessagePack;

--- a/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/JavaConcreteMessageType.java
+++ b/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/JavaConcreteMessageType.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.gruchalski.kafka.serializer.java8;
+package com.gruchalski.kafka.test.serializer.java8.concrete;
 
-public interface IdProvider {
-    int id();
+import com.gruchalski.kafka.test.serializer.java8.IdProvider;
+
+public abstract class JavaConcreteMessageType implements IdProvider {
 }

--- a/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/JavaConcreteSerializer.java
+++ b/src/test/java/com/gruchalski/kafka/test/serializer/java8/concrete/JavaConcreteSerializer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.gruchalski.kafka.serializer.java8.concrete;
+package com.gruchalski.kafka.test.serializer.java8.concrete;
 
 import org.apache.kafka.common.serialization.Serializer;
 import org.msgpack.core.MessageBufferPacker;

--- a/src/test/resources/invalid.conf
+++ b/src/test/resources/invalid.conf
@@ -22,7 +22,7 @@ com.gruchalski {
       acks = -1
       max-block-ms = 60000
       buffer-size = 1048576
-      retries = 0
+      retries = -1 # this is an invalid value
       linger-ms = 0
       request-timeout-ms = 10240
       security-protocol = "plaintext"
@@ -30,7 +30,7 @@ com.gruchalski {
 
     consumer {
       group-id = "group"
-      auto-offset-reset = "earliest",
+      auto-offset-reset = "invalid-value",
       partition-fetch-size = 4096,
       session-timeout = 30000
     }

--- a/src/test/scala/com/gruchalski/kafka/test/KafkaInvalidConfigurationTest.scala
+++ b/src/test/scala/com/gruchalski/kafka/test/KafkaInvalidConfigurationTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Radek Gruchalski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gruchalski.kafka.test
+
+import java.io.File
+import java.util.Scanner
+
+import com.gruchalski.kafka.scala.{Configuration, KafkaCluster, KafkaTopicCreateResult, KafkaTopicStatus}
+import com.gruchalski.kafka.test.serializer.scala.TestConcreteProvider
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Milliseconds, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, Inside, Matchers, WordSpec}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+class KafkaInvalidConfigurationTest extends WordSpec with Matchers with Eventually with Inside with BeforeAndAfterAll {
+
+  override implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(100, Milliseconds)))
+
+  implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+  implicit val config: Config = ConfigFactory.parseFile(new File(getClass.getClassLoader.getResource("invalid.conf").toURI))
+  val cluster = KafkaCluster()
+  val clusterConfig = new Configuration(config);
+
+  override def beforeAll(): Unit = {
+    cluster.start() match {
+      case Some(safe) ⇒
+        val topics = safe.configuration.`com.gruchalski.kafka.topics`.flatten
+        @volatile var topicCreateStatuses = List.empty[KafkaTopicCreateResult]
+        Future.sequence(safe.cluster.withTopics(topics)).onComplete {
+          case Success(statuses) ⇒
+            topicCreateStatuses = statuses
+          case Failure(ex) ⇒
+            fail(ex)
+        }
+        eventually {
+          topicCreateStatuses should matchPattern {
+            case List(
+              KafkaTopicCreateResult(_, KafkaTopicStatus.Exists(), None),
+              KafkaTopicCreateResult(_, KafkaTopicStatus.Exists(), None)) ⇒
+          }
+        }
+      case None ⇒ fail("Expected Kafka cluster to come up.")
+    }
+  }
+
+  override def afterAll(): Unit = {
+    cluster.stop()
+  }
+
+  "Kafka cluster" must {
+
+    "gracefully handle errors" when {
+
+      "invalid Kafka producer configuration is given" in {
+        cluster.produce(
+          clusterConfig.`com.gruchalski.kafka.topics`.head.get.name,
+          TestConcreteProvider.ConcreteExample()
+        ).toEither should matchPattern { case Left(_) ⇒ }
+      }
+
+      "invalid Kafka consumer configuration is given" in {
+        implicit val deserializer = TestConcreteProvider.ConcreteExample().deserializer()
+        cluster.consume[TestConcreteProvider.ConcreteExample](
+          clusterConfig.`com.gruchalski.kafka.topics`.head.get.name
+        ).toEither should matchPattern { case Left(_) ⇒ }
+      }
+
+    }
+
+  }
+
+}

--- a/src/test/scala/com/gruchalski/kafka/test/KafkaNonExistingTopicTest.scala
+++ b/src/test/scala/com/gruchalski/kafka/test/KafkaNonExistingTopicTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Radek Gruchalski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gruchalski.kafka.test
+
+import java.io.File
+import java.util.Scanner
+
+import com.gruchalski.kafka.scala.{Configuration, KafkaCluster, KafkaTopicCreateResult, KafkaTopicStatus}
+import com.gruchalski.kafka.test.serializer.scala.TestConcreteProvider
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Milliseconds, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, Inside, Matchers, WordSpec}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+class KafkaNonExistingTopicTest extends WordSpec with Matchers with Eventually with Inside with BeforeAndAfterAll {
+
+  override implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(100, Milliseconds)))
+
+  implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+  val cluster = KafkaCluster()
+  var clusterConfig: Configuration = _
+
+  override def beforeAll(): Unit = {
+    cluster.start() match {
+      case Some(safe) ⇒
+        val topics = safe.configuration.`com.gruchalski.kafka.topics`.flatten
+        @volatile var topicCreateStatuses = List.empty[KafkaTopicCreateResult]
+        Future.sequence(safe.cluster.withTopics(topics)).onComplete {
+          case Success(statuses) ⇒
+            topicCreateStatuses = statuses
+          case Failure(ex) ⇒
+            fail(ex)
+        }
+        eventually {
+          topicCreateStatuses should matchPattern {
+            case List(
+              KafkaTopicCreateResult(_, KafkaTopicStatus.Exists(), None),
+              KafkaTopicCreateResult(_, KafkaTopicStatus.Exists(), None)) ⇒
+          }
+        }
+        clusterConfig = safe.configuration
+      case None ⇒ fail("Expected Kafka cluster to come up.")
+    }
+  }
+
+  override def afterAll(): Unit = {
+    cluster.stop()
+  }
+
+  "Kafka cluster" must {
+
+    "gracefully handle errors" when {
+
+      "a message is consumed from a non-existing topic" in {
+        implicit val deserializer = TestConcreteProvider.ConcreteExample().deserializer()
+        cluster.consume[TestConcreteProvider.ConcreteExample](
+          "non-existing-topic"
+        ).toEither should matchPattern { case Left(_) ⇒ }
+      }
+
+    }
+
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "1.1.0-SNAPSHOT"
+version := "1.1.0"


### PR DESCRIPTION
- add logging
- `produce` is now `Try[Option[Future[RecordMetadata]]]`
- `consume` is now `Try[Option[ConsumedItem[T]]]`
- relevant changes in the Java API: `produce` and `consume` now throw `Throwable`
- updates readme
- consume will not attempt subscribing to a topic which has not been created to avoid cluttering unit test output